### PR TITLE
Allow Public Key Retrieval when using MySQL

### DIFF
--- a/src/main/java/pw/twpi/whitelistsync2/service/MySqlService.java
+++ b/src/main/java/pw/twpi/whitelistsync2/service/MySqlService.java
@@ -22,7 +22,7 @@ public class MySqlService implements BaseService {
 
     public MySqlService() {
         this.databaseName = WhitelistSync2.CONFIG.getString("mysql.database-name");
-        this.url = "jdbc:mysql://" + WhitelistSync2.CONFIG.getString("mysql.ip") + ":" + WhitelistSync2.CONFIG.getString("mysql.port") + "/?useSSL=false";
+        this.url = "jdbc:mysql://" + WhitelistSync2.CONFIG.getString("mysql.ip") + ":" + WhitelistSync2.CONFIG.getString("mysql.port") + "/?allowPublicKeyRetrieval=true&useSSL=false";
         this.username = WhitelistSync2.CONFIG.getString("mysql.username");
         this.password = WhitelistSync2.CONFIG.getString("mysql.password");
     }


### PR DESCRIPTION
Fixes an error that is very similar to this issue: https://github.com/PotatoSauceVFX/Whitelist-Sync-2/issues/19

Another possible fix would be to have an option in the config to disable/enable SSL and/or Public Key Retrival